### PR TITLE
[BUGFIX] Restore open document selector class

### DIFF
--- a/Resources/Private/Templates/ToolbarItems/DropDown.html
+++ b/Resources/Private/Templates/ToolbarItems/DropDown.html
@@ -23,7 +23,7 @@
                     </a>
                 </li>
                 <f:for each="{openDocuments}" as="openDocument">
-                    <li>
+                    <li class="t3js-topbar-opendocs-item">
                         <a href="{openDocument.uri}" class="dropdown-item dropdown-item-title t3js-open-doc"
                             data-pid="{openDocument.label}"
                             title="{openDocument.label}">


### PR DESCRIPTION
The opendocs toolbar was unable to update the counter badge because the OpendocsMenu JavaScript module cannot count the open documents displayed in the dropdown list

Fixes: https://forge.typo3.org/issues/103980